### PR TITLE
Give the pom and eclipse feature the same name.

### DIFF
--- a/feature.xml
+++ b/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="imp.runtime.feature"
+      id="org.eclipse.imp.runtime.feature"
       label="IMP runtime"
       version="0.2.1.qualifier"
       image="eclipse_update_120.jpg">

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>imp.runtime.feature</artifactId>
+	<artifactId>org.eclipse.imp.runtime.feature</artifactId>
 	<version>0.2.1.qualifier</version>
 	<packaging>eclipse-feature</packaging>
 


### PR DESCRIPTION
Right now, the pom.xml tells maven this artifact is called "org.eclipse.imp.imp.runtime.feature" (due to the groupId) and the feature.xml tells Tycho that this artifact is called "imp.runtime.feature". I couldn't figure out how to actually get an updatesite to successfully build with this as it is.

This patch changes both to agree on the name "org.eclipse.imp.runtime.feature".

I scanned through: https://github.com/search?q=%22imp.runtime.feature%22&type=Code&utf8=%E2%9C%93

It looks like the impacted projects as a result of this change would be the Rascal updatesite and feature:

https://github.com/cwi-swat/rascal-feature  (feature.xml)
https://github.com/cwi-swat/rascal-update-site   (category.xml and pom.xml)

Those would need references to this feature updated.

I'm still a little bit baffled that this works for you guys as-is. I couldn't get it to. This change fixes things for me, so I thought the issue was that Tycho was unable to find the Maven artifact because of the differing names. But if it works for you... maybe I'm also doing something else weird?
